### PR TITLE
Update pom parent and liquibase config for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target/
 /.idea
 *.iml
 .toDelete
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -5,7 +5,7 @@ spring:
       dialect: org.hibernate.dialect.H2Dialect
       hibernate.format_sql: true
     hibernate:
-      #to turn off schema validation that fails (because of clob types) and blocks tests even if the the schema is compatible
+      #to turn off schema validation that fails (because of clob types) and blocks tests even if the schema is compatible
       ddl-auto: none
 logging:
   level:
@@ -17,7 +17,7 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"
 
 


### PR DESCRIPTION
Update POM parent, like on other projects using Liquibase, to keep up-to-date
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54