### PR TITLE
Fix Spring native metadata after the add of Spel in @Value

### DIFF
--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,5 +1,17 @@
 [
 {
   "name":"[Ljava.util.UUID;"
+},
+{
+  "name":"org.springframework.core.env.AbstractEnvironment",
+  "methods":[{"name":"getProperty","parameterTypes":["java.lang.String"]}]
+},
+{
+  "name":"co.elastic.clients.elasticsearch._types.mapping.TypeMapping",
+  "fields":[{"name":"_DESERIALIZER"}]
+},
+{
+  "name":"co.elastic.clients.elasticsearch.indices.IndexSettings",
+  "fields":[{"name":"_DESERIALIZER"}]
 }
 ]

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qelasticsearch_settings.json\\E"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
* After the add of Spel with the getProperty() method inside the `@Document` annotation: https://github.com/gridsuite/directory-server/blob/91468f333afdfe52853e629fdefc8df9c0a0f91f/src/main/java/org/gridsuite/directory/server/dto/elasticsearch/DirectoryElementInfos.java#L29
The following error is thrown when starting the service in native:
```
Caused by: org.springframework.expression.spel.SpelEvaluationException: EL1004E: Method call: Method getProperty(java.lang.String) cannot be found on type org.springframework.boot.web.servlet.context.ApplicationServletEnvironment
   	at org.springframework.expression.spel.ast.MethodReference.findAccessorForMethod(MethodReference.java:225) ~[na:na]
   	at org.springframework.expression.spel.ast.MethodReference.getValueInternal(MethodReference.java:135) ~[na:na]
   	at org.springframework.expression.spel.ast.MethodReference$MethodValueRef.getValue(MethodReference.java:380) ~[na:na]
   	at org.springframework.expression.spel.ast.CompoundExpression.getValueInternal(CompoundExpression.java:96) ~[na:na]
   	at org.springframework.expression.spel.ast.SpelNodeImpl.getTypedValue(SpelNodeImpl.java:119) ~[org.gridsuite.directory.server.DirectoryApplication:6.0.11]
   	at org.springframework.expression.spel.standard.SpelExpression.getValue(SpelExpression.java:309) ~[na:na]
   	at org.springframework.expression.common.CompositeStringExpression.getValue(CompositeStringExpression.java:108) ~[na:na]
   	at org.springframework.expression.common.CompositeStringExpression.getValue(CompositeStringExpression.java:121) ~[na:na]
   	at org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentEntity.resolve(SimpleElasticsearchPersistentEntity.java:353) ~[org.gridsuite.directory.server.DirectoryApplication:5.1.2]
   	at org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentEntity.resolve(SimpleElasticsearchPersistentEntity.java:335) ~[org.gridsuite.directory.server.DirectoryApplication:5.1.2]
   	at org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentEntity.getIndexCoordinates(SimpleElasticsearchPersistentEntity.java:134) ~[org.gridsuite.directory.server.DirectoryApplication:5.1.2]
   	at org.springframework.data.elasticsearch.client.elc.IndicesTemplate.getIndexCoordinatesFor(IndicesTemplate.java:450) ~[na:na]
   	at org.springframework.data.elasticsearch.client.elc.IndicesTemplate.getIndexCoordinates(IndicesTemplate.java:446) ~[na:na]
   	at org.springframework.data.elasticsearch.client.elc.IndicesTemplate.exists(IndicesTemplate.java:169) ~[na:na]
   	at org.springframework.data.elasticsearch.repository.support.SimpleElasticsearchRepository.<init>(SimpleElasticsearchRepository.java:83) ~[org.gridsuite.directory.server.DirectoryApplication:5.1.2]
   	at java.base@17.0.7/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[org.gridsuite.directory.server.DirectoryApplication:na]
   	at java.base@17.0.7/java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[org.gridsuite.directory.server.DirectoryApplication:na]
   	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:211) ~[na:na]
   	... 81 common frames omitted
```
Adding the missing method named in the stacktrace to metadata fix this issue. This issue is mentioned https://github.com/spring-attic/spring-native/issues/768 

* The metadata involving `_DESERIALIZER` is not necessary in recent versions of `spring-data-elasticsearch`, this was fixed in May 2023: https://github.com/spring-projects/spring-data-elasticsearch/pull/2579 (related issue https://github.com/spring-projects/spring-data-elasticsearch/issues/2565)
* The elasticsearch_settings.json is not discovered at build time so it needs to be added to resource-config.json. 