### PR TITLE
Filter out orphan elements when searching

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryService.java
@@ -600,8 +600,11 @@ public class DirectoryService {
             elementInfos.setPathName(path.stream().map(ElementAttributes::getElementName).toList());
             return elementInfos;
         } catch (DirectoryException ex) {
-            LOGGER.error("Error retrieving path for element: (id: {}, name: {}, owner: {}, parent element id: {}). {}", elementInfos.getId(), elementInfos.getName(), elementInfos.getOwner(), elementInfos.getParentId(), ex.getMessage());
-            return null;
+            if (ex.getType() == DirectoryException.Type.NOT_FOUND) {
+                LOGGER.error("Error retrieving path for element: '{}' : {}", elementInfos, ex.getMessage());
+                return null;
+            }
+            throw ex;
         }
     }
 

--- a/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
@@ -1768,4 +1768,42 @@ public class DirectoryTest {
             output.clear(); // purge in order to not fail the other tests
         }
     }
+
+    @Test
+    public void testSearchWithOrphans() throws Exception {
+        //     root
+        //   /       \
+        // dir1     dir2
+        ElementAttributes rootDirectory = retrieveInsertAndCheckRootDirectory("directory", USERID_1);
+        UUID rootDirectoryUuid = rootDirectory.getElementUuid();
+        // dir1
+        UUID subDirUuid1 = UUID.randomUUID();
+        ElementAttributes subDirAttributes1 = toElementAttributes(subDirUuid1, "newSubDir1", DIRECTORY, USERID_1);
+        insertAndCheckSubElement(rootDirectoryUuid, subDirAttributes1);
+        insertAndCheckSubElement(subDirUuid1, toElementAttributes(UUID.randomUUID(), RECOLLEMENT, STUDY, USERID_1, ""));
+        // dir2
+        UUID subDirUuid2 = UUID.randomUUID();
+        ElementAttributes subDirAttributes2 = toElementAttributes(subDirUuid2, "newSubDir2", DIRECTORY, USERID_1);
+        insertAndCheckSubElement(rootDirectoryUuid, subDirAttributes2);
+        insertAndCheckSubElement(subDirUuid2, toElementAttributes(UUID.randomUUID(), RECOLLEMENT, STUDY, USERID_1, ""));
+
+        MvcResult mvcResult = mockMvc
+                .perform(get("/v1/elements/indexation-infos?userInput={request}", "r").header(USER_ID, USERID_1))
+                .andExpectAll(status().isOk()).andReturn();
+        List<Object> result = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
+        assertEquals(2, result.size());
+        output.clear();
+
+        //                              root
+        //                    /                           \
+        // dir1 (deleted but keeping its sub-elements)     dir2
+        directoryElementRepository.deleteById(subDirUuid1);
+
+        mvcResult = mockMvc
+                .perform(get("/v1/elements/indexation-infos?userInput={request}", "r").header(USER_ID, USERID_1))
+                .andExpectAll(status().isOk()).andReturn();
+        result = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
+        assertEquals(1, result.size());
+        output.clear();
+    }
 }


### PR DESCRIPTION
In the current implementation, an exception in getPath() is thrown (returning a 404 not found) in searchElements endpoint when:
* the database is inconsistent and some "parent_id" are not present anymore in the DB. The orphan elements can be listed with: `SELECT p.* FROM directory.element p LEFT JOIN directory.element c ON p.parent_id = c.id WHERE p.parent_id IS NOT NULL AND c.id IS NULL;`
* an element referenced in ElasticSearch is not referenced in the database anymore. This can be fixed by reindexing the elements or by adding a code to remove these elements.

In this PR, I filter out these elements (that are DB orphans or ES orphans) and print an error log instead of throwing and returning 404 not found when searching an element. These orphans should not exist in normal execution.


