### PR TITLE
Add missing config

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/repository/JPAConfig.java
+++ b/src/main/java/org/gridsuite/directory/server/repository/JPAConfig.java
@@ -1,0 +1,18 @@
+/*
+  Copyright (c) 2024, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.directory.server.repository;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@Configuration
+@EnableJpaRepositories
+public class JPAConfig {
+}


### PR DESCRIPTION
Fix the message when Spring starts:
```
2024-07-11T10:14:48.502+02:00  INFO 1323371 --- [           main] .RepositoryConfigurationExtensionSupport : Spring Data JPA - Could not safely identify store assignment for repository candidate interface org.gridsuite.directory.server.elasticsearch.DirectoryElementInfosRepository; If you want this repository to be a JPA repository, consider annotating your entities with one of these annotations: jakarta.persistence.Entity, jakarta.persistence.MappedSuperclass (preferred), or consider extending one of the following types with your repository: org.springframework.data.jpa.repository.JpaRepository
```
This JPAConfig is already added in our other services with ElasticSearch repositories (study-server, network-modification-server). It was probably forgotten when added in this one.