### PR TITLE
Enrich spring native metadata

### DIFF
--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,17 +1,21 @@
 [
-{
-  "name":"[Ljava.util.UUID;"
-},
-{
-  "name":"org.springframework.core.env.AbstractEnvironment",
-  "methods":[{"name":"getProperty","parameterTypes":["java.lang.String"]}]
-},
-{
-  "name":"co.elastic.clients.elasticsearch._types.mapping.TypeMapping",
-  "fields":[{"name":"_DESERIALIZER"}]
-},
-{
-  "name":"co.elastic.clients.elasticsearch.indices.IndexSettings",
-  "fields":[{"name":"_DESERIALIZER"}]
-}
+  {
+    "condition":{"typeReachable":"org.hibernate.loader.ast.internal.MultiIdEntityLoaderArrayParam"},
+    "name":"[Ljava.util.UUID;"
+  },
+  {
+    "condition":{"typeReachable":"org.springframework.core.env.AbstractEnvironment"},
+    "name":"org.springframework.core.env.AbstractEnvironment",
+    "methods":[{"name":"getProperty","parameterTypes":["java.lang.String"]}]
+  },
+  {
+    "condition":{"typeReachable":"co.elastic.clients.elasticsearch._types.mapping.TypeMapping"},
+    "name":"co.elastic.clients.elasticsearch._types.mapping.TypeMapping",
+    "fields":[{"name":"_DESERIALIZER"}]
+  },
+  {
+    "condition":{"typeReachable":"co.elastic.clients.elasticsearch.indices.IndexSettings"},
+    "name":"co.elastic.clients.elasticsearch.indices.IndexSettings",
+    "fields":[{"name":"_DESERIALIZER"}]
+  }
 ]

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "\\Qelasticsearch_settings.json\\E"
+      },
+      {
+        "pattern":"\\Qorg/gridsuite/directory/server/repository/DirectoryElementRepository$SubDirectoryCount.class\\E"
       }
     ]
   }


### PR DESCRIPTION
* Add resource-config to fix info message in logs: "Couldn't read class metadata for interface org.gridsuite.directory.server.repository.DirectoryElementRepository$SubDirectoryCount. Input property calculation might fail". This is a nested projection interface that is not correctly accounted for at compile time.
* Add conditions to reflection metadata to be able to move reflect-config.json in ws-commons later.