### PR TITLE
Decode path for createElementInDirectoryPath endpoint

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/DirectoryController.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryController.java
@@ -21,6 +21,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -81,7 +83,8 @@ public class DirectoryController {
     })
     public ResponseEntity<Void> createElementInDirectoryPath(@RequestParam("directoryPath") String directoryPath, @RequestBody ElementAttributes elementAttributes,
                                               @RequestHeader("userId") String userId) {
-        service.createElementInDirectoryPath(directoryPath, elementAttributes, userId);
+        String decodedDirectoryPath = URLDecoder.decode(directoryPath, StandardCharsets.UTF_8);
+        service.createElementInDirectoryPath(decodedDirectoryPath, elementAttributes, userId);
         return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).build();
     }
 

--- a/src/test/java/org/gridsuite/directory/server/DirectoryControllerTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryControllerTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.directory.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gridsuite.directory.server.dto.ElementAttributes;
+import org.gridsuite.directory.server.services.DirectoryRepositoryService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@RunWith(SpringRunner.class)
+@WebMvcTest(DirectoryController.class)
+public class DirectoryControllerTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DirectoryService directoryService;
+
+    @MockBean
+    private DirectoryRepositoryService directoryRepositoryService;
+
+    @Test
+    public void testCreateElementWithEncodedPath() throws Exception {
+        String encodedPath = "%26~%23%7B%5B%5Eimport%C3%A9%22";
+        String decodedPath = "&~#{[^importé\"";
+        String userId = "testUser";
+        String requestBody = new ObjectMapper().writeValueAsString(ElementAttributes.builder().build());
+        mockMvc.perform(post("/v1/directories/paths/elements")
+                        .param("directoryPath", encodedPath)
+                        .content(requestBody)
+                        .header("userId", userId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
+        verify(directoryService).createElementInDirectoryPath(eq(decodedPath), any(), eq(userId));
+    }
+}


### PR DESCRIPTION
This endpoint is used in case-import-server and when used, it creates folders like "Point fig%C3%A9s" because the path is not decoded in the controller while it's encoded in the request in case-import-server.