### PR TITLE
Add default binder for rabbit to fix logs in native 

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -6,6 +6,7 @@ spring:
     function:
       definition: consumeStudyUpdate;consumeElementUpdate
     stream:
+      default-binder: rabbit
       bindings:
         publishDirectoryUpdate-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}directory.update


### PR DESCRIPTION
In the native version of directory-server on main branch, some logs appears "No specific name or default given - using single available child initializer 'rabbit'" since Spring and dependencies upgrade.
Spring Cloud changed some log levels from debug to info (https://github.com/spring-cloud/spring-cloud-stream/commit/a2d4bddf082e218385c8850d8875de1854343790#diff-171a19cc53e372c53aa61e31f2cbacd26851f2cdef5e848529f65a92e685c381R194) which pollutes directory-server logs in its native version.
I thus added the default binder to fix these logs and be compliant with what they request.