### PR TITLE
Override powsybl-ws-commons version to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
         <to-string-verifier-version>1.4.8</to-string-verifier-version>
         <native-buildtools.version>0.10.3</native-buildtools.version>
         <db-util.version>1.0.5</db-util.version>
+        <!-- FIXME: powsybl-ws-commons version is overridden. To be removed at next powsybl-ws-dependencies.version upgrade -->
+        <powsybl-ws-commons.version>1.15.0</powsybl-ws-commons.version>
     </properties>
 
     <profiles>
@@ -158,6 +160,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- overrides of imports -->
+            <!-- FIXME: powsybl-ws-commons version is overridden. To be removed at next powsybl-ws-dependencies.version upgrade -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-ws-commons</artifactId>
+                <version>${powsybl-ws-commons.version}</version>
+            </dependency>
+
             <!-- imports -->
             <dependency>
                 <groupId>org.gridsuite</groupId>


### PR DESCRIPTION
Since upgrade to springboot 3.3, we need powsybl-ws-commons 1.15.0 to set max-http-request-header-size to 64000. 
Without this property, we get a "Request header is too large" when we have hundreds of elements in a directory.