### PR TITLE
Fix: add UserGroupDTO to native image reflection configuration

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/services/UserAdminService.java
+++ b/src/main/java/org/gridsuite/directory/server/services/UserAdminService.java
@@ -8,6 +8,7 @@ package org.gridsuite.directory.server.services;
 
 import lombok.Setter;
 import org.gridsuite.directory.server.dto.UserGroupDTO;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -50,6 +51,12 @@ public class UserAdminService {
         }
     }
 
+    /**
+     * Register UserGroupDTO for reflection in native image builds.
+     * This annotation ensures Spring's AOT compiler includes the necessary reflection
+     * metadata for Jackson to properly deserialize REST responses into UserGroupDTO objects.
+     */
+    @RegisterReflectionForBinding(UserGroupDTO.class)
     public List<UserGroupDTO> getUserGroups(String sub) {
         String path = UriComponentsBuilder.fromPath(DELIMITER + USER_ADMIN_API_VERSION + GET_USER_GROUPS_URI)
                 .buildAndExpand(sub).toUriString();

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -6,6 +6,15 @@
     }
   },
   {
+    "name": "org.gridsuite.directory.server.dto.UserGroupDTO",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
     "name":"org.springframework.core.env.AbstractEnvironment",
     "condition": {
       "typeReachable":"org.springframework.core.env.AbstractEnvironment"

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -6,15 +6,6 @@
     }
   },
   {
-    "name": "org.gridsuite.directory.server.dto.UserGroupDTO",
-    "allDeclaredConstructors": true,
-    "allPublicConstructors": true,
-    "allDeclaredFields": true,
-    "allPublicFields": true,
-    "allDeclaredMethods": true,
-    "allPublicMethods": true
-  },
-  {
     "name":"org.springframework.core.env.AbstractEnvironment",
     "condition": {
       "typeReachable":"org.springframework.core.env.AbstractEnvironment"


### PR DESCRIPTION
Add UserGroupDTO to reflect-config.json to allow proper deserialization
in GraalVM native image builds. This fixes deserialization errors when 
UserAdminService attempts to fetch user groups.