### PR TITLE
fix(permissions): don't throw with strict mode if filtered by permissions

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryService.java
@@ -499,15 +499,15 @@ public class DirectoryService {
     public List<ElementAttributes> getElements(List<UUID> ids, boolean strictMode, List<String> types, String userId) {
         List<DirectoryElementEntity> elementEntities = repositoryService.findAllByIdIn(ids);
 
+        if (strictMode && elementEntities.size() != ids.stream().distinct().count()) {
+            throw new DirectoryException(NOT_FOUND);
+        }
+
         //if the user is not an admin we filter out elements he doesn't have the permission on
         if (!roleService.isUserExploreAdmin()) {
             elementEntities = elementEntities.stream().filter(directoryElementEntity ->
                             hasReadPermissions(userId, List.of(directoryElementEntity.getId()))
                     ).toList();
-        }
-
-        if (strictMode && elementEntities.size() != ids.stream().distinct().count()) {
-            throw new DirectoryException(NOT_FOUND);
         }
 
         Map<UUID, Long> subElementsCount = getSubDirectoriesCounts(elementEntities.stream().map(DirectoryElementEntity::getId).toList(), types);


### PR DESCRIPTION
With strict mode activated it should throw only if the first fetch return incomplete list of items. It is then considered normal behavior if the list is filtered by permissions, even in strict mode.