### PR TITLE
feat: add an endpoint returning the path of several elements

### DIFF
--- a/src/main/java/org/gridsuite/directory/server/DirectoryController.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryController.java
@@ -108,6 +108,13 @@ public class DirectoryController {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getPath(elementUuid));
     }
 
+    @GetMapping(value = "/elements/paths", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Get the path of several elements")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The path of each element, unknown elements are omitted")})
+    public ResponseEntity<Map<UUID, List<ElementAttributes>>> getPaths(@RequestParam("ids") List<UUID> elementUuids) {
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getPaths(elementUuids));
+    }
+
     @GetMapping(value = "/elements/{elementUuid}/name", produces = MediaType.TEXT_PLAIN_VALUE)
     @Operation(summary = "Get name of element")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Name of an element"),

--- a/src/main/java/org/gridsuite/directory/server/DirectoryController.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryController.java
@@ -110,7 +110,7 @@ public class DirectoryController {
 
     @GetMapping(value = "/elements/paths", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Get the path of several elements")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The path of each element, unknown elements are omitted")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The path of each element")})
     public ResponseEntity<Map<UUID, List<ElementAttributes>>> getPaths(@RequestParam("ids") List<UUID> elementUuids) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getPaths(elementUuids));
     }

--- a/src/main/java/org/gridsuite/directory/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryService.java
@@ -523,6 +523,25 @@ public class DirectoryService {
         return path;
     }
 
+    /***
+     * Retrieve the path of several elements at once
+     * @param elementUuids elements uuids
+     * @return the path of each element, indexed by element uuid.
+     */
+    public Map<UUID, List<ElementAttributes>> getPaths(List<UUID> elementUuids) {
+        Map<UUID, List<DirectoryElementEntity>> pathsCache = new HashMap<>();
+        Map<UUID, List<ElementAttributes>> paths = new HashMap<>();
+        elementUuids.stream().distinct().forEach(elementUuid -> {
+            List<ElementAttributes> path = repositoryService.getPath(elementUuid, pathsCache).stream()
+                .map(ElementAttributes::toElementAttributes)
+                .toList();
+            if (!path.isEmpty()) {
+                paths.put(elementUuid, path);
+            }
+        });
+        return paths;
+    }
+
     public String getElementName(UUID elementUuid) {
         DirectoryElementEntity element = repositoryService.getElementEntity(elementUuid)
             .orElseThrow(() -> DirectoryException.createElementNotFound(ELEMENT, elementUuid));

--- a/src/main/java/org/gridsuite/directory/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryService.java
@@ -158,8 +158,7 @@ public class DirectoryService {
             now,
             now,
             elementAttributes.getOwner(),
-            // references may be null when deserialized from a request that omits them (e.g. a plain element creation)
-            Optional.ofNullable(elementAttributes.getReferences()).orElseGet(List::of).stream().map(this::createReferenceEntity).toList());
+            elementAttributes.getReferences().stream().map(this::createReferenceEntity).toList());
 
         return tryInsertElement(elementEntity, parentDirectoryUuid, userId, generateNewName);
     }

--- a/src/main/java/org/gridsuite/directory/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/directory/server/DirectoryService.java
@@ -158,7 +158,8 @@ public class DirectoryService {
             now,
             now,
             elementAttributes.getOwner(),
-            elementAttributes.getReferences().stream().map(this::createReferenceEntity).toList());
+            // references may be null when deserialized from a request that omits them (e.g. a plain element creation)
+            Optional.ofNullable(elementAttributes.getReferences()).orElseGet(List::of).stream().map(this::createReferenceEntity).toList());
 
         return tryInsertElement(elementEntity, parentDirectoryUuid, userId, generateNewName);
     }

--- a/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
@@ -409,8 +409,9 @@ public class DirectoryTest {
         insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(element3UUID, "element3", TYPE_03, "Doe"));
         UUID unknownElementUuid = UUID.randomUUID();
 
+        // ids are sent as repeated query params, as UriComponentsBuilder does on the caller side
         String result = mockMvc.perform(get("/v1/elements/paths")
-                        .param("ids", element1UUID + "," + element2UUID + "," + element3UUID + "," + unknownElementUuid)
+                        .param("ids", element1UUID.toString(), element2UUID.toString(), element3UUID.toString(), unknownElementUuid.toString())
                         .header("userId", "Doe"))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();

--- a/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
@@ -392,6 +392,47 @@ public class DirectoryTest {
     }
 
     @Test
+    public void testGetPaths() throws Exception {
+        // Insert a root directory
+        UUID rootDirUuid = insertAndCheckRootDirectory("rootDir1", "Doe");
+
+        // Insert a subDirectory1 in the root directory
+        UUID directory1UUID = UUID.randomUUID();
+        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(directory1UUID, "directory1", DIRECTORY, "Doe"));
+
+        // Insert two elements in the subDirectory1, and one directly in the root directory
+        UUID element1UUID = UUID.randomUUID();
+        insertAndCheckSubElement(directory1UUID, toElementAttributes(element1UUID, "element1", TYPE_03, "Doe"));
+        UUID element2UUID = UUID.randomUUID();
+        insertAndCheckSubElement(directory1UUID, toElementAttributes(element2UUID, "element2", TYPE_03, "Doe"));
+        UUID element3UUID = UUID.randomUUID();
+        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(element3UUID, "element3", TYPE_03, "Doe"));
+
+        UUID unknownElementUuid = UUID.randomUUID();
+        String result = mockMvc.perform(get("/v1/elements/paths")
+                        .param("ids", element1UUID + "," + element2UUID + "," + element3UUID + "," + unknownElementUuid)
+                        .header("userId", "Doe"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        Map<UUID, List<ElementAttributes>> paths = objectMapper.readValue(result, new TypeReference<>() { });
+
+        // the unknown element is omitted rather than failing the whole call
+        assertEquals(3, paths.size());
+        assertEquals(
+                Arrays.asList(rootDirUuid, directory1UUID, element1UUID),
+                paths.get(element1UUID).stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList())
+        );
+        assertEquals(
+                Arrays.asList(rootDirUuid, directory1UUID, element2UUID),
+                paths.get(element2UUID).stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList())
+        );
+        assertEquals(
+                Arrays.asList(rootDirUuid, element3UUID),
+                paths.get(element3UUID).stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList())
+        );
+    }
+
+    @Test
     public void testTwoUsersTwoPublicDirectories() throws Exception {
         checkRootDirectoriesList("user1", List.of());
         checkRootDirectoriesList("user2", List.of());

--- a/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
@@ -398,7 +398,7 @@ public class DirectoryTest {
 
         // Insert a subDirectory1 in the root directory
         UUID directoryUUID = UUID.randomUUID();
-        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(directoryUUID, "directory1", DIRECTORY, "Doe"));
+        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(directoryUUID, "subDirectory1", DIRECTORY, "Doe"));
 
         // Insert two elements in the subDirectory1, and one directly in the root directory
         UUID element1UUID = UUID.randomUUID();

--- a/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
+++ b/src/test/java/org/gridsuite/directory/server/DirectoryTest.java
@@ -397,18 +397,18 @@ public class DirectoryTest {
         UUID rootDirUuid = insertAndCheckRootDirectory("rootDir1", "Doe");
 
         // Insert a subDirectory1 in the root directory
-        UUID directory1UUID = UUID.randomUUID();
-        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(directory1UUID, "directory1", DIRECTORY, "Doe"));
+        UUID directoryUUID = UUID.randomUUID();
+        insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(directoryUUID, "directory1", DIRECTORY, "Doe"));
 
         // Insert two elements in the subDirectory1, and one directly in the root directory
         UUID element1UUID = UUID.randomUUID();
-        insertAndCheckSubElement(directory1UUID, toElementAttributes(element1UUID, "element1", TYPE_03, "Doe"));
+        insertAndCheckSubElement(directoryUUID, toElementAttributes(element1UUID, "element1", TYPE_03, "Doe"));
         UUID element2UUID = UUID.randomUUID();
-        insertAndCheckSubElement(directory1UUID, toElementAttributes(element2UUID, "element2", TYPE_03, "Doe"));
+        insertAndCheckSubElement(directoryUUID, toElementAttributes(element2UUID, "element2", TYPE_03, "Doe"));
         UUID element3UUID = UUID.randomUUID();
         insertAndCheckSubElementInRootDir(rootDirUuid, toElementAttributes(element3UUID, "element3", TYPE_03, "Doe"));
-
         UUID unknownElementUuid = UUID.randomUUID();
+
         String result = mockMvc.perform(get("/v1/elements/paths")
                         .param("ids", element1UUID + "," + element2UUID + "," + element3UUID + "," + unknownElementUuid)
                         .header("userId", "Doe"))
@@ -419,11 +419,11 @@ public class DirectoryTest {
         // the unknown element is omitted rather than failing the whole call
         assertEquals(3, paths.size());
         assertEquals(
-                Arrays.asList(rootDirUuid, directory1UUID, element1UUID),
+                Arrays.asList(rootDirUuid, directoryUUID, element1UUID),
                 paths.get(element1UUID).stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList())
         );
         assertEquals(
-                Arrays.asList(rootDirUuid, directory1UUID, element2UUID),
+                Arrays.asList(rootDirUuid, directoryUUID, element2UUID),
                 paths.get(element2UUID).stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList())
         );
         assertEquals(


### PR DESCRIPTION
Add `GET /v1/elements/paths?ids=`, returning the path of each given element, indexed by element uuid. Each path is ordered from the root directory to the element itself, and unknown elements are omitted rather than failing the whole call.